### PR TITLE
Anki 2.1: Hook loadNote instead of replacing it entirely

### DIFF
--- a/src/frozen_fields/main.py
+++ b/src/frozen_fields/main.py
@@ -160,9 +160,13 @@ def loadNote21(self, focusTo=None):
     sticky = [fld["sticky"] for fld in flds]
 
     eval_definitions = js_code_21 % (hotkey_toggle_field, iconstr_frozen, iconstr_unfrozen)
-
     self.web.eval(eval_definitions)
-    self.web.eval("addFreezeButtons(%s, %s)" % (json.dumps(sticky), len(flds)))
+
+    def oncallback(arg):
+        if focusTo is not None:
+            self.web.setFocus()
+
+    self.web.evalWithCallback("addFreezeButtons(%s, %s)" % (json.dumps(sticky), len(flds)), oncallback)
 
 
 def onBridge(self, str, _old):


### PR DESCRIPTION
It's more compatible with other addons and less prone to breakage in case `aqt.editor.Editor.loadNote` gets changed.

Fixes compatibility with the [Add note id](https://ankiweb.net/shared/info/1672832404) addon, which didn't work previously with this addon installed.