### PR TITLE
add window.event in onKey

### DIFF
--- a/src/frozen_fields/config.py
+++ b/src/frozen_fields/config.py
@@ -9,11 +9,11 @@ Copyright: (c) 2018 Glutanimate <https://glutanimate.com/>
 License: GNU AGPLv3 <https://www.gnu.org/licenses/agpl.html>
 """
 
-import os
 import io
+import os
 
-from aqt import mw
 from anki.utils import json
+from aqt import mw
 
 from .consts import *
 

--- a/src/frozen_fields/consts.py
+++ b/src/frozen_fields/consts.py
@@ -9,8 +9,9 @@ Copyright: (c) 2018 Glutanimate <https://glutanimate.com/>
 License: GNU AGPLv3 <https://www.gnu.org/licenses/agpl.html>
 """
 
-import sys
 import os
+import sys
+
 from anki import version
 
 anki21 = version.startswith("2.1.")

--- a/src/frozen_fields/js20.js
+++ b/src/frozen_fields/js20.js
@@ -1,0 +1,36 @@
+function onFrozen(elem) {
+    currentField = elem;
+    py.run("frozen:" + currentField.id.substring(1));
+}
+
+function setFrozenFields(fields, frozen, focusTo) {
+    var txt = "";
+    for (var i=0; i<fields.length; i++) {
+        var n = fields[i][0];
+        var f = fields[i][1];
+        if (!f) {
+            f = "<br>";
+        }
+        txt += "<tr><td style='min-width: 28'></td><td class=fname>{0}</td></tr><tr>".format(n);
+        if (frozen[i]) {
+            txt += "<td style='min-width: 28'><div id=i{0} title='Unfreeze field (%s)' onclick='onFrozen(this);'><img src='%s'/></div></td>".format(i);
+        }
+        else {
+            txt += "<td style='min-width: 28'><div id=i{0} title='Freeze field (%s)' onclick='onFrozen(this);'><img src='%s'/></div></td>".format(i);
+        }
+        txt += "<td width=100%%>"
+        txt += "<div id=f{0} onkeydown='onKey(window.event);' onmouseup='onKey(window.event);'".format(i);
+        txt += " onfocus='onFocus(this);' onblur='onBlur();' class=field ";
+        txt += "ondragover='onDragOver(this);' ";
+        txt += "contentEditable=true class=field>{0}</div>".format(f);
+        txt += "</td>"
+        txt += "</td></tr>";
+    }
+    $("#fields").html("<table cellpadding=0 width=100%%>"+txt+"</table>");
+    if (!focusTo) {
+        focusTo = 0;
+    }
+    if (focusTo >= 0) {
+        $("#f"+focusTo).focus();
+    }
+};

--- a/src/frozen_fields/js21.js
+++ b/src/frozen_fields/js21.js
@@ -12,23 +12,23 @@ function setFrozenFields(fields, frozen) {
             f = "<br>";
         }
         // ----------- mod start -----------
-        txt += "<tr><td style='width:28px'></td><td class=fname>{0}</td></tr><tr>".format(n);
+        txt += "<tr><td style='width:28px'></td><td class=fname>"+n+"</td></tr><tr>";
 
         if (frozen[i]) {
-            txt += "<td style='width:28px'><div id=i{0} title='Unfreeze field (%s)' onclick='onFrozen(this);'><img src='%s'/></div></td>".format(i);
+            txt += "<td style='width:28px'><div id=i"+i+" title='Unfreeze field (%s)' onclick='onFrozen(this);'><img src='%s'/></div></td>";
         }
         else {
-            txt += "<td style='width:28px'><div id=i{0} title='Freeze field (%s)' onclick='onFrozen(this);'><img src='%s'/></div></td>".format(i);
+            txt += "<td style='width:28px'><div id=i"+i+" title='Freeze field (%s)' onclick='onFrozen(this);'><img src='%s'/></div></td>";
         }
 
         txt += "<td width=100%%>"
         // -----------  mod end -----------
         
-        txt += "<div id=f{0} onkeydown='onKey(window.event);' oninput='onInput()' onmouseup='onKey(window.event);'".format(i);
+        txt += "<div id=f"+i+" onkeydown='onKey(window.event);' oninput='onInput()' onmouseup='onKey(window.event);'";
         txt += " onfocus='onFocus(this);' onblur='onBlur();' class='field clearfix' ";
         txt += "ondragover='onDragOver(this);' onpaste='onPaste(this);' ";
         txt += "oncopy='onCutOrCopy(this);' oncut='onCutOrCopy(this);' ";
-        txt += "contentEditable=true class=field>{0}</div>".format(f);
+        txt += "contentEditable=true class=field>"+f+"</div>";
 
         // ----------- mod start -----------
         txt += "</td>"

--- a/src/frozen_fields/js21.js
+++ b/src/frozen_fields/js21.js
@@ -1,7 +1,17 @@
 function onFrozen(elem, idx) {
+    wasFrozen = frozenFields[idx];
     pycmd("frozen:" + idx);
     wasFrozen = frozenFields[idx];
     frozenFields[idx] = !wasFrozen;
+    $div = $(elem);
+    $img = $div.find("img");
+    if (wasFrozen) {
+        elem.title = "Freeze field ("+hotkey_toggle_field+")";
+        $img.attr("src", src_unfrozen);
+    } else {
+        elem.title = "Unfreeze field ("+hotkey_toggle_field+")";
+        $img.attr("src", src_frozen);
+    }
 }
 
 var hotkey_toggle_field = "%s";

--- a/src/frozen_fields/js21.js
+++ b/src/frozen_fields/js21.js
@@ -3,6 +3,8 @@ function onFrozen(elem, idx) {
 }
 
 var hotkey_toggle_field = "%s";
+var src_frozen = "%s";
+var src_unfrozen = "%s";
 
 function setFrozenFields(fields, frozen) {
     var txt = "";
@@ -16,10 +18,10 @@ function setFrozenFields(fields, frozen) {
         txt += "<tr><td style='width:28px'></td><td class=fname>"+n+"</td></tr><tr>";
 
         if (frozen[i]) {
-            txt += "<td style='width:28px'><div id=i"+i+" title='Unfreeze field ("+hotkey_toggle_field+")' onclick='onFrozen(this, "+i+");'><img src='%s'/></div></td>";
+            txt += "<td style='width:28px'><div id=i"+i+" title='Unfreeze field ("+hotkey_toggle_field+")' onclick='onFrozen(this, "+i+");'><img src='"+src_frozen+"'/></div></td>";
         }
         else {
-            txt += "<td style='width:28px'><div id=i"+i+" title='Freeze field ("+hotkey_toggle_field+")' onclick='onFrozen(this, "+i+");'><img src='%s'/></div></td>";
+            txt += "<td style='width:28px'><div id=i"+i+" title='Freeze field ("+hotkey_toggle_field+")' onclick='onFrozen(this, "+i+");'><img src='"+src_unfrozen+"'/></div></td>";
         }
 
         txt += "<td width=100%%>"

--- a/src/frozen_fields/js21.js
+++ b/src/frozen_fields/js21.js
@@ -1,0 +1,42 @@
+function onFrozen(elem) {
+    currentField = elem;
+    pycmd("frozen:" + currentField.id.substring(1));
+}
+
+function setFrozenFields(fields, frozen) {
+    var txt = "";
+    for (var i=0; i<fields.length; i++) {
+        var n = fields[i][0];
+        var f = fields[i][1];
+        if (!f) {
+            f = "<br>";
+        }
+        // ----------- mod start -----------
+        txt += "<tr><td style='width:28px'></td><td class=fname>{0}</td></tr><tr>".format(n);
+
+        if (frozen[i]) {
+            txt += "<td style='width:28px'><div id=i{0} title='Unfreeze field (%s)' onclick='onFrozen(this);'><img src='%s'/></div></td>".format(i);
+        }
+        else {
+            txt += "<td style='width:28px'><div id=i{0} title='Freeze field (%s)' onclick='onFrozen(this);'><img src='%s'/></div></td>".format(i);
+        }
+
+        txt += "<td width=100%%>"
+        // -----------  mod end -----------
+        
+        txt += "<div id=f{0} onkeydown='onKey(window.event);' oninput='onInput()' onmouseup='onKey(window.event);'".format(i);
+        txt += " onfocus='onFocus(this);' onblur='onBlur();' class='field clearfix' ";
+        txt += "ondragover='onDragOver(this);' onpaste='onPaste(this);' ";
+        txt += "oncopy='onCutOrCopy(this);' oncut='onCutOrCopy(this);' ";
+        txt += "contentEditable=true class=field>{0}</div>".format(f);
+
+        // ----------- mod start -----------
+        txt += "</td>"
+        // -----------  mod end -----------
+
+        txt += "</td></tr>";
+    }
+    $("#fields").html("<table cellpadding=0 width=100%% style='table-layout: fixed;'>" + txt + "</table>");
+    maybeDisableButtons();
+}
+

--- a/src/frozen_fields/js21.js
+++ b/src/frozen_fields/js21.js
@@ -1,6 +1,5 @@
-function onFrozen(elem) {
-    currentField = elem;
-    pycmd("frozen:" + currentField.id.substring(1));
+function onFrozen(elem, idx) {
+    pycmd("frozen:" + idx);
 }
 
 function setFrozenFields(fields, frozen) {
@@ -15,10 +14,10 @@ function setFrozenFields(fields, frozen) {
         txt += "<tr><td style='width:28px'></td><td class=fname>"+n+"</td></tr><tr>";
 
         if (frozen[i]) {
-            txt += "<td style='width:28px'><div id=i"+i+" title='Unfreeze field (%s)' onclick='onFrozen(this);'><img src='%s'/></div></td>";
+            txt += "<td style='width:28px'><div id=i"+i+" title='Unfreeze field (%s)' onclick='onFrozen(this, "+i+");'><img src='%s'/></div></td>";
         }
         else {
-            txt += "<td style='width:28px'><div id=i"+i+" title='Freeze field (%s)' onclick='onFrozen(this);'><img src='%s'/></div></td>";
+            txt += "<td style='width:28px'><div id=i"+i+" title='Freeze field (%s)' onclick='onFrozen(this, "+i+");'><img src='%s'/></div></td>";
         }
 
         txt += "<td width=100%%>"

--- a/src/frozen_fields/js21.js
+++ b/src/frozen_fields/js21.js
@@ -2,6 +2,8 @@ function onFrozen(elem, idx) {
     pycmd("frozen:" + idx);
 }
 
+var hotkey_toggle_field = "%s";
+
 function setFrozenFields(fields, frozen) {
     var txt = "";
     for (var i=0; i<fields.length; i++) {
@@ -14,10 +16,10 @@ function setFrozenFields(fields, frozen) {
         txt += "<tr><td style='width:28px'></td><td class=fname>"+n+"</td></tr><tr>";
 
         if (frozen[i]) {
-            txt += "<td style='width:28px'><div id=i"+i+" title='Unfreeze field (%s)' onclick='onFrozen(this, "+i+");'><img src='%s'/></div></td>";
+            txt += "<td style='width:28px'><div id=i"+i+" title='Unfreeze field ("+hotkey_toggle_field+")' onclick='onFrozen(this, "+i+");'><img src='%s'/></div></td>";
         }
         else {
-            txt += "<td style='width:28px'><div id=i"+i+" title='Freeze field (%s)' onclick='onFrozen(this, "+i+");'><img src='%s'/></div></td>";
+            txt += "<td style='width:28px'><div id=i"+i+" title='Freeze field ("+hotkey_toggle_field+")' onclick='onFrozen(this, "+i+");'><img src='%s'/></div></td>";
         }
 
         txt += "<td width=100%%>"

--- a/src/frozen_fields/js21.js
+++ b/src/frozen_fields/js21.js
@@ -1,12 +1,17 @@
 function onFrozen(elem, idx) {
     pycmd("frozen:" + idx);
+    wasFrozen = frozenFields[idx];
+    frozenFields[idx] = !wasFrozen;
 }
 
 var hotkey_toggle_field = "%s";
 var src_frozen = "%s";
 var src_unfrozen = "%s";
 
+var frozenFields = null;
+
 function setFrozenFields(fields, frozen) {
+    frozenFields = frozen;
     var txt = "";
     for (var i=0; i<fields.length; i++) {
         var n = fields[i][0];

--- a/src/frozen_fields/main.py
+++ b/src/frozen_fields/main.py
@@ -114,7 +114,7 @@ def loadNote21(self, focusTo=None):
         sticky = [fld["sticky"] for fld in flds]
 
         eval_definitions = js_code_21 % (hotkey_toggle_field, iconstr_frozen,
-                                         hotkey_toggle_field, iconstr_unfrozen)
+                                         iconstr_unfrozen)
 
         eval_calls = "setFrozenFields(%s, %s); setFonts(%s); focusField(%s); setNoteId(%s)" % (
             json.dumps(data), json.dumps(sticky),

--- a/src/frozen_fields/main.py
+++ b/src/frozen_fields/main.py
@@ -14,16 +14,14 @@ License: GNU AGPLv3 <https://www.gnu.org/licenses/agpl.html>
 
 import os
 
+from anki.hooks import addHook, runHook, wrap
+from anki.utils import json
+from aqt.addcards import AddCards
+from aqt.editor import Editor
 from aqt.qt import *
 
-from aqt.editor import Editor
-from aqt.addcards import AddCards
-
-from anki.hooks import wrap, addHook, runHook
-from anki.utils import json
-
-from .consts import *
 from .config import local_conf
+from .consts import *
 
 icon_path = os.path.join(addon_path, "icons")
 
@@ -209,7 +207,7 @@ def loadNote21(self, focusTo=None):
 
 def onBridge(self, str, _old):
     """Extends the js<->py bridge with our pycmd handler"""
-    
+
     if not str.startswith("frozen"):
         if anki21 and str.startswith("blur"):
             self.lastField = self.currentField  # save old focus
@@ -253,8 +251,10 @@ def frozenToggle(self, batch=False):
         self.web.eval("saveField('key');")
         self.loadNote()
 
+
 def onFrozenToggle21(self, batch=False):
-    self.web.evalWithCallback("saveField('key');", lambda _: self.frozenToggle(batch=batch))
+    self.web.evalWithCallback(
+        "saveField('key');", lambda _: self.frozenToggle(batch=batch))
 
 
 def onSetupButtons20(self):

--- a/src/frozen_fields/main.py
+++ b/src/frozen_fields/main.py
@@ -34,91 +34,12 @@ icon_unfrozen = QUrl.fromLocalFile(icon_path_unfrozen).toString()
 hotkey_toggle_field = local_conf["hotkeyOne"]
 hotkey_toggle_all = local_conf["hotkeyAll"]
 
-
-js_code_20 = """
-function onFrozen(elem) {
-    currentField = elem;
-    py.run("frozen:" + currentField.id.substring(1));
-}
-
-function setFrozenFields(fields, frozen, focusTo) {
-    var txt = "";
-    for (var i=0; i<fields.length; i++) {
-        var n = fields[i][0];
-        var f = fields[i][1];
-        if (!f) {
-            f = "<br>";
-        }
-        txt += "<tr><td style='min-width: 28'></td><td class=fname>{0}</td></tr><tr>".format(n);
-        if (frozen[i]) {
-            txt += "<td style='min-width: 28'><div id=i{0} title='Unfreeze field (%s)' onclick='onFrozen(this);'><img src='%s'/></div></td>".format(i);
-        }
-        else {
-            txt += "<td style='min-width: 28'><div id=i{0} title='Freeze field (%s)' onclick='onFrozen(this);'><img src='%s'/></div></td>".format(i);
-        }
-        txt += "<td width=100%%>"
-        txt += "<div id=f{0} onkeydown='onKey(window.event);' onmouseup='onKey(window.event);'".format(i);
-        txt += " onfocus='onFocus(this);' onblur='onBlur();' class=field ";
-        txt += "ondragover='onDragOver(this);' ";
-        txt += "contentEditable=true class=field>{0}</div>".format(f);
-        txt += "</td>"
-        txt += "</td></tr>";
-    }
-    $("#fields").html("<table cellpadding=0 width=100%%>"+txt+"</table>");
-    if (!focusTo) {
-        focusTo = 0;
-    }
-    if (focusTo >= 0) {
-        $("#f"+focusTo).focus();
-    }
-};
-""" % (hotkey_toggle_field, icon_frozen, hotkey_toggle_field, icon_unfrozen)
-
-
-js_code_21 = """
-function onFrozen(elem) {
-    currentField = elem;
-    pycmd("frozen:" + currentField.id.substring(1));
-}
-
-function setFrozenFields(fields, frozen) {
-    var txt = "";
-    for (var i=0; i<fields.length; i++) {
-        var n = fields[i][0];
-        var f = fields[i][1];
-        if (!f) {
-            f = "<br>";
-        }
-        // ----------- mod start -----------
-        txt += "<tr><td style='width:28px'></td><td class=fname>{0}</td></tr><tr>".format(n);
-        
-        if (frozen[i]) {
-            txt += "<td style='width:28px'><div id=i{0} title='Unfreeze field (%s)' onclick='onFrozen(this);'><img src='%s'/></div></td>".format(i);
-        }
-        else {
-            txt += "<td style='width:28px'><div id=i{0} title='Freeze field (%s)' onclick='onFrozen(this);'><img src='%s'/></div></td>".format(i);
-        }
-        
-        txt += "<td width=100%%>"
-        // -----------  mod end -----------
-        
-        txt += "<div id=f{0} onkeydown='onKey();' oninput='onInput()' onmouseup='onKey();'".format(i);
-        txt += " onfocus='onFocus(this);' onblur='onBlur();' class='field clearfix' ";
-        txt += "ondragover='onDragOver(this);' onpaste='onPaste(this);' ";
-        txt += "oncopy='onCutOrCopy(this);' oncut='onCutOrCopy(this);' ";
-        txt += "contentEditable=true class=field>{0}</div>".format(f);
-
-        // ----------- mod start -----------
-        txt += "</td>"
-        // -----------  mod end -----------
-
-        txt += "</td></tr>";
-    }
-    $("#fields").html("<table cellpadding=0 width=100%% style='table-layout: fixed;'>" + txt + "</table>");
-    maybeDisableButtons();
-}
-
-"""
+__location__ = os.path.realpath(
+    os.path.join(os.getcwd(), os.path.dirname(__file__)))
+with open(os.path.join(__location__, "js20.js"), "r") as f:
+          js_code_20 = f.read() % (hotkey_toggle_field, icon_frozen, hotkey_toggle_field, icon_unfrozen)
+with open(os.path.join(__location__, "js21.js"), "r") as f:
+          js_code_21 = f.read()
 
 
 def loadNote20(self):

--- a/src/frozen_fields/main.py
+++ b/src/frozen_fields/main.py
@@ -142,10 +142,7 @@ def onBridge(self, str, _old):
     flds = self.note.model()['flds']
     flds[cur]['sticky'] = not flds[cur]['sticky']
 
-    if anki21:
-        # load and restore old focus
-        self.loadNote(focusTo=getattr(self, "lastField", None))
-    else:
+    if not anki21:
         self.loadNote()
 
 

--- a/src/frozen_fields/main.py
+++ b/src/frozen_fields/main.py
@@ -59,7 +59,7 @@ function setFrozenFields(fields, frozen, focusTo) {
             txt += "<td style='min-width: 28'><div id=i{0} title='Freeze field (%s)' onclick='onFrozen(this);'><img src='%s'/></div></td>".format(i);
         }
         txt += "<td width=100%%>"
-        txt += "<div id=f{0} onkeydown='onKey();' onmouseup='onKey();'".format(i);
+        txt += "<div id=f{0} onkeydown='onKey(window.event);' onmouseup='onKey(window.event);'".format(i);
         txt += " onfocus='onFocus(this);' onblur='onBlur();' class=field ";
         txt += "ondragover='onDragOver(this);' ";
         txt += "contentEditable=true class=field>{0}</div>".format(f);


### PR DESCRIPTION
This port dae/anki@ddb4db0c9618d67d22a35bd7eb1baf664a3d2f6d
It's related to the fact that now, onKey expect an event.

And it'll make disappear the line "JS error on line 40: Uncaught
TypeError: Cannot read property 'which' of undefined" which keeps
popping when I run anki in a terminal with your addon

#### Description

*Concisely describe what the pull request is trying to achieve. If pertinent, link to an existing issue report, or briefly explain the problem the PR is meant to solve. Feel free to attach screenshots or other media for UI-related changes.*


#### Checklist:

*Please replace the space inside the brackets with an **x** and fill out the ellipses if the following items apply:*

- [ ] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [x] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [x] Latest standard Anki 2.1 binary build [required for Anki-compatible 2.1 add-ons]
  - [ ] Latest alternative Anki 2.1 binary build
  - [ ] Latest Anki 2.0 binary build [required for Anki 2.0-compatible add-ons]
- [x] I've tested my changes on at least one of the following platforms:
  - [x] Linux, version:
  - [ ] Windows, version:
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
