### PR TITLE
Use webview_did_receive_js_message hook instead of patching onBridgeCmd

### DIFF
--- a/src/frozen_fields/config.py
+++ b/src/frozen_fields/config.py
@@ -39,10 +39,13 @@ from .consts import *
 defaults_path = os.path.join(addon_path, "config.json")
 meta_path = os.path.join(addon_path, "meta.json")
 
+
 def getConfig():
     return mw.addonManager.getConfig(__name__)
 
+
 def writeConfig(config):
     mw.addonManager.writeConfig(__name__, config)
+
 
 local_conf = getConfig()

--- a/src/frozen_fields/editor.py
+++ b/src/frozen_fields/editor.py
@@ -107,21 +107,24 @@ def loadNote(self, focusTo=None):
         self.web.evalWithCallback(eval_calls, oncallback)
 
 
-def onBridge(self, str, _old):
+def onBridge(handled, message, context):
+    self = context
     """Extends the js<->py bridge with our pycmd handler"""
-
-    if not str.startswith("frozen"):
-        if str.startswith("blur"):
+    if not isinstance(context, Editor):
+        return handled
+    if not message.startswith("frozen"):
+        if message.startswith("blur"):
             self.lastField = self.currentField  # save old focus
-        return _old(self, str)
+        return handled
     if not self.note or not runHook:
         # shutdown
-        return
+        return handled
 
-    (cmd, txt) = str.split(":", 1)
+    (cmd, txt) = message.split(":", 1)
     cur = int(txt)
     flds = self.note.model()['flds']
     flds[cur]['sticky'] = not flds[cur]['sticky']
+    return (True, None)
 
 
 def frozenToggle(self, batch=False):
@@ -159,7 +162,7 @@ def onSetupShortcuts(cuts, self):
 
 def initializeEditor():
     addHook("setupEditorShortcuts", onSetupShortcuts)
-    Editor.onBridgeCmd = wrap(Editor.onBridgeCmd, onBridge, "around")
+    gui_hooks.webview_did_receive_js_message.append(onBridge)
     Editor.loadNote = loadNote
     Editor.onFrozenToggle = onFrozenToggle
 

--- a/src/frozen_fields/editor.py
+++ b/src/frozen_fields/editor.py
@@ -36,6 +36,7 @@ import os
 
 from anki.hooks import addHook, runHook, wrap
 from anki.utils import json
+from aqt import gui_hooks
 from aqt.addcards import AddCards
 from aqt.editor import Editor
 from aqt.qt import *
@@ -77,11 +78,7 @@ def loadNote(self, focusTo=None):
         self.checkValid()
         if focusTo is not None:
             self.web.setFocus()
-        try:
-            from aqt import gui_hooks
-            gui_hooks.editor_did_load_note(self)
-        except:
-            runHook("loadNote", self)
+        gui_hooks.editor_did_load_note(self)
 
     # only modify AddCards Editor
     if not isinstance(self.parentWindow, AddCards):
@@ -158,6 +155,7 @@ def onSetupShortcuts(cuts, self):
     # third value: enable shortcut even when no field selected
 
 # Add-on hooks, etc.
+
 
 def initializeEditor():
     addHook("setupEditorShortcuts", onSetupShortcuts)


### PR DESCRIPTION
#### Description

This uses webview_did_receive_js_message instead of changing onBridgeCmd.
Since this code is for >20, I assumed I could remove the try/except around the import, and just import in top of the file


#### Checklist:

*Please replace the space inside the brackets with an **x** and fill out the ellipses if the following items apply:*

- [ ] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [x] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [x] Latest standard Anki 2.1 binary build [required for Anki-compatible 2.1 add-ons]
  - [ ] Latest alternative Anki 2.1 binary build
  - [ ] Latest Anki 2.0 binary build [required for Anki 2.0-compatible add-ons]
- [ ] I've tested my changes on at least one of the following platforms:
  - [x] Linux, version:
  - [ ] Windows, version:
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
