### PR TITLE
added option to remove clozes in frozen fields

### DIFF
--- a/src/frozen_fields/config.json
+++ b/src/frozen_fields/config.json
@@ -1,4 +1,5 @@
 {
     "hotkeyOne": "F9",
-    "hotkeyAll": "Shift+F9"
+    "hotkeyAll": "Shift+F9",
+    "removeClozesInFrozenFields":true
 }

--- a/src/frozen_fields/main.py
+++ b/src/frozen_fields/main.py
@@ -82,12 +82,15 @@ def loadNote21(self, focusTo=None):
         return
 
     data = []
+    data2 = []
     for fld, val in list(self.note.items()):
         if remove_clozes_from_frozen_fields:
+            val2=val
             for i in range(100):
-                val=find_clozed_expressions(val,i)
+                val2=find_clozed_expressions(val2,i)
     
         data.append((fld, self.mw.col.media.escapeImages(val)))
+        data2.append((fld, self.mw.col.media.escapeImages(val2)))
     self.widget.show()
     self.updateTags()
 
@@ -122,7 +125,7 @@ def loadNote21(self, focusTo=None):
                                          iconstr_unfrozen)
 
         eval_calls = "setFrozenFields(%s, %s); setFonts(%s); focusField(%s); setNoteId(%s)" % (
-            json.dumps(data), json.dumps(sticky),
+            json.dumps(data2), json.dumps(sticky),
             json.dumps(self.fonts()),
             json.dumps(focusTo),
             json.dumps(self.note.id))


### PR DESCRIPTION
#### Description

Added an option to automatically delete the cloze-prompts (i.e. "{{c1::" and "}}") upon creating a new note.
  

![Animation](https://user-images.githubusercontent.com/65167682/233518361-55f9780d-f661-46e5-aa1f-e342875758c7.gif)

### Why is this useful?

Imagine you want to cloze the following information:

![grafik](https://user-images.githubusercontent.com/65167682/233518853-d691cb52-ec29-44d0-9d78-a367d058233a.png)

If you create the cloze like this:
![grafik](https://user-images.githubusercontent.com/65167682/233519003-f14a595e-35e0-46db-b113-dbf8efbc077a.png)

You will face the following problem:
![grafik](https://user-images.githubusercontent.com/65167682/233519099-9e1fc0c7-49d8-4edb-85f8-abc89f692b1a.png)

Here, the information, that she won an Oscar, already hints that she is an actor. 
So, what do you do instead?

Create multiple clozes in the following manner:
![grafik](https://user-images.githubusercontent.com/65167682/233519356-e3316b4e-4338-41f8-9644-5c9567bfb0c0.png)

and
![grafik](https://user-images.githubusercontent.com/65167682/233519418-30bfe569-d43c-44c8-ba8d-659bc5aed19c.png)








#### Checklist:

*Please replace the space inside the brackets with an **x** and fill out the ellipses if the following items apply:*

- [x] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [x] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [x] Latest standard Anki 2.1 binary build
  - [ ] Latest alternative Anki 2.1 binary build
- [x] I've tested my changes on at least one of the following platforms:
  - [ ] Linux, version:
  - [x] Windows, version:
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
